### PR TITLE
deprecated error solve

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,9 +7,10 @@ import cors from "cors";
 
 dotenv.config();
 const app = express();
+app.use(express.urlencoded({extended: true})); 
 app.use(cors());
 
-app.use(bodyParser.json());
+app.use(express.json());
 const port = process.env.PORT || 4000;
 
 app.listen(port, () => {


### PR DESCRIPTION
app.use(bodyParser.json()); is showing a deprecated error because bodyParser.json() no longer exists instead of this we use express.json().